### PR TITLE
chore: ci release needs public access

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,4 +66,4 @@ jobs:
       - name: NPM Publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        run: npx ipjs publish
+        run: cd dist && npm publish --access=public


### PR DESCRIPTION
Per https://github.com/web3-storage/car-block-validator/actions/runs/4384443439/jobs/7675941679#step:6:113