### PR TITLE
fix: downgrade deps to have cjs support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@multiformats/blake2": "^1.0.13",
-        "@multiformats/murmur3": "^2.1.3",
+        "@multiformats/murmur3": "^1.1.3",
         "@multiformats/sha3": "^2.0.15",
-        "multiformats": "^11.0.2",
-        "uint8arrays": "^4.0.3"
+        "multiformats": "9.9.0",
+        "uint8arrays": "^3.1.1"
       },
       "devDependencies": {
         "@ipld/car": "^5.1.0",
@@ -140,6 +140,16 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@ipld/car/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@ipld/dag-cbor": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
@@ -149,6 +159,16 @@
         "cborg": "^1.10.0",
         "multiformats": "^11.0.0"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -167,6 +187,16 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@multiformats/blake2": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-1.0.13.tgz",
@@ -176,22 +206,13 @@
         "multiformats": "^9.5.4"
       }
     },
-    "node_modules/@multiformats/blake2/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
     "node_modules/@multiformats/murmur3": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.3.tgz",
-      "integrity": "sha512-YvLK1IrLnRckPsvXhOkZjaIGNonsEdD1dL3NPSaLilV/WjVYeBgnNZXTUsaPzFXGrIFM7motx+yCmmqzXO6gtQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
+      "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
       "dependencies": {
-        "multiformats": "^11.0.0",
+        "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/@multiformats/sha3": {
@@ -202,11 +223,6 @@
         "js-sha3": "^0.8.0",
         "multiformats": "^9.5.4"
       }
-    },
-    "node_modules/@multiformats/sha3/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3093,13 +3109,9 @@
       "dev": true
     },
     "node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -4700,15 +4712,11 @@
       }
     },
     "node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
       "dependencies": {
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   ],
   "dependencies": {
     "@multiformats/blake2": "^1.0.13",
-    "@multiformats/murmur3": "^2.1.3",
+    "@multiformats/murmur3": "^1.1.3",
     "@multiformats/sha3": "^2.0.15",
-    "multiformats": "^11.0.2",
-    "uint8arrays": "^4.0.3"
+    "multiformats": "9.9.0",
+    "uint8arrays": "^3.1.1"
   },
   "devDependencies": {
     "@ipld/car": "^5.1.0",


### PR DESCRIPTION
https://github.com/elastic-ipfs/indexer-lambda is CJS and we can't install all the new shiny things... Unfortunately, these deps recently shipped ESM only. I saw latest release content, and we should be good for now to downgrade and make things work. 

We should discuss wether we should move elastic-ipfs into the new world, or upcoming fixes won't land...

- `murmur3@2.0.0` https://github.com/multiformats/js-murmur3/releases 
- `multiformats@10.0.0` https://github.com/multiformats/js-multiformats/releases
- `uint8arrays@4.0.0` https://github.com/achingbrain/uint8arrays/releases